### PR TITLE
Fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 
             <h1>Why the Movement</h1>
             <p>
-                Every time a team uses a framework, it also takes a <strong>risk</strong>. The risk is that after some time has passed the team ends up with a tool that does not provide any kind of value anymore and that most of the times represents a major roadblock to change. Most importantly a framework could "die" way before the software that uses it, leaving the developers with a heavy burden.
+                Every time a team uses a framework, it also takes a <strong>risk</strong>. The risk is that after some time has passed the team ends up with a tool that does not provide any kind of value anymore and that most of the times represents a major roadblock to change. Most importantly a framework could "die" way before the software uses it, leaving the developers with a heavy burden.
             </p>
             <p>
                 This risk is amplified without the presence of a strong bond between technical decision making, business goals, and user experience. Instead, the non-functional requirements like deadline, lifespan, budget, usability, future business scenarios and domain-specific constraints should be the primary decision drivers for the architectural choices as well as for the implementation roadmap.


### PR DESCRIPTION
Remove stray word: "that" on section: "Why the Movement"